### PR TITLE
Revamp home UI with glassmorphism styling

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,6 +1,9 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../data/models/restaurant_info.dart';
 import '../providers/app_state.dart';
 import '../widgets/dish_card.dart';
 import '../widgets/order_status_banner.dart';
@@ -12,6 +15,7 @@ class HomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final appState = context.watch<AppState>();
+    final theme = Theme.of(context);
     final categories = appState.categories;
     final selectedCategories = appState.selectedCategoryIds;
     final restaurantInfo = appState.restaurantInfo;
@@ -25,145 +29,110 @@ class HomeScreen extends StatelessWidget {
         : selectedCategoryTitles.length == 1
             ? selectedCategoryTitles.first
             : 'Выбрано: ${selectedCategoryTitles.length}';
+    final hasSelections = selectedCategories.isNotEmpty;
 
-    return DecoratedBox(
-      decoration: const BoxDecoration(
-        gradient: LinearGradient(
-          colors: [Color(0xFFFDF5F5), Color(0xFFFFFCF8)],
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-        ),
-      ),
-      child: RefreshIndicator(
-        onRefresh: () async => appState.initialize(),
-        edgeOffset: 140,
-        child: CustomScrollView(
-          slivers: [
-            SliverAppBar(
-              pinned: true,
-              backgroundColor: Colors.transparent,
-              surfaceTintColor: Colors.transparent,
-              elevation: 0,
-              expandedHeight: 160,
-              flexibleSpace: FlexibleSpaceBar(
-                titlePadding: const EdgeInsetsDirectional.only(start: 24, bottom: 16),
-                title: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      restaurantInfo.name.isNotEmpty ? restaurantInfo.name : 'Ресторан',
-                      style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                            fontWeight: FontWeight.w700,
-                          ),
-                    ),
-                    if (restaurantInfo.workingHours.isNotEmpty)
-                      Text(
-                        restaurantInfo.workingHours,
-                        style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                              color: Colors.white.withOpacity(0.85),
-                              fontWeight: FontWeight.w500,
+    return Stack(
+      children: [
+        const _HomeBackground(),
+        RefreshIndicator(
+          onRefresh: () async => appState.initialize(),
+          edgeOffset: 180,
+          displacement: 16,
+          color: theme.colorScheme.primary,
+          child: CustomScrollView(
+            physics: const BouncingScrollPhysics(
+              parent: AlwaysScrollableScrollPhysics(),
+            ),
+            slivers: [
+              SliverAppBar(
+                pinned: true,
+                backgroundColor: Colors.transparent,
+                surfaceTintColor: Colors.transparent,
+                elevation: 0,
+                expandedHeight: 220,
+                automaticallyImplyLeading: false,
+                flexibleSpace: LayoutBuilder(
+                  builder: (context, constraints) {
+                    final progress = ((constraints.maxHeight - kToolbarHeight) /
+                            (220 - kToolbarHeight))
+                        .clamp(0.0, 1.0);
+                    final collapsedOpacity = 1 - progress;
+                    final displayName = restaurantInfo.name.isNotEmpty
+                        ? restaurantInfo.name
+                        : 'Ресторан';
+                    return Stack(
+                      fit: StackFit.expand,
+                      children: [
+                        FlexibleSpaceBar(
+                          collapseMode: CollapseMode.pin,
+                          titlePadding:
+                              const EdgeInsetsDirectional.only(start: 24, bottom: 16),
+                          title: Opacity(
+                            opacity: collapsedOpacity.clamp(0.0, 1.0),
+                            child: Text(
+                              displayName,
+                              style: theme.textTheme.titleLarge,
                             ),
-                      ),
-                  ],
+                          ),
+                          background: Padding(
+                            padding: const EdgeInsets.fromLTRB(24, 48, 24, 0),
+                            child: _HeroHeader(info: restaurantInfo, progress: progress),
+                          ),
+                        ),
+                      ],
+                    );
+                  },
                 ),
-                background: Padding(
-                  padding: const EdgeInsets.fromLTRB(24, 48, 24, 0),
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(28),
-                      gradient: const LinearGradient(
-                        colors: [Color(0xFF9C2B31), Color(0xFFD96441)],
-                        begin: Alignment.topLeft,
-                        end: Alignment.bottomRight,
-                      ),
-                    ),
-                    child: Padding(
-                      padding: const EdgeInsets.all(24),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            restaurantInfo.name.isNotEmpty
-                                ? 'Добро пожаловать в ${restaurantInfo.name}!'
-                                : 'Добро пожаловать в ваш ресторан!'
-                                    ' Настройте название в административной панели.',
-                            style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                                  color: Colors.white,
-                                  fontWeight: FontWeight.w700,
-                                ),
+                actions: [
+                  Padding(
+                    padding: const EdgeInsets.only(right: 16, top: 8, bottom: 8),
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        color: Colors.white.withOpacity(0.9),
+                        borderRadius: BorderRadius.circular(18),
+                        boxShadow: [
+                          BoxShadow(
+                            color: theme.colorScheme.primary.withOpacity(0.15),
+                            blurRadius: 18,
+                            offset: const Offset(0, 10),
                           ),
-                          const SizedBox(height: 12),
-                          Text(
-                            'Выбирайте категории, собирайте корзину и отслеживайте статус заказа в реальном времени.',
-                            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                                  color: Colors.white.withOpacity(0.82),
-                                ),
-                          ),
-                          if (restaurantInfo.workingHours.isNotEmpty ||
-                              restaurantInfo.phone.isNotEmpty)
-                            const SizedBox(height: 16),
-                          if (restaurantInfo.workingHours.isNotEmpty ||
-                              restaurantInfo.phone.isNotEmpty)
-                            Wrap(
-                              spacing: 12,
-                              runSpacing: 12,
-                              children: [
-                                if (restaurantInfo.workingHours.isNotEmpty)
-                                  _buildInfoChip(
-                                    context,
-                                    Icons.schedule_outlined,
-                                    restaurantInfo.workingHours,
-                                  ),
-                                if (restaurantInfo.phone.isNotEmpty)
-                                  _buildInfoChip(
-                                    context,
-                                    Icons.phone_outlined,
-                                    restaurantInfo.phone,
-                                  ),
-                              ],
-                            ),
                         ],
                       ),
+                      child: IconButton(
+                        icon: const Icon(Icons.admin_panel_settings_outlined),
+                        color: theme.colorScheme.primary,
+                        onPressed: () =>
+                            Navigator.pushNamed(context, AdminLoginScreen.routeName),
+                      ),
                     ),
                   ),
-                ),
+                ],
               ),
-              actions: [
-                Padding(
-                  padding: const EdgeInsets.only(right: 12),
-                  child: IconButton(
-                    icon: const Icon(Icons.admin_panel_settings_outlined),
-                    color: Colors.white,
-                    onPressed: () => Navigator.pushNamed(context, AdminLoginScreen.routeName),
-                  ),
-                ),
-              ],
-            ),
-            const SliverToBoxAdapter(child: SizedBox(height: 16)),
-            const SliverToBoxAdapter(child: OrderStatusBanner()),
-            SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-                child: Material(
-                  elevation: 2,
-                  borderRadius: BorderRadius.circular(24),
-                  color: Colors.white,
-                  child: Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 16, 16, 20),
+              const SliverToBoxAdapter(child: SizedBox(height: 12)),
+              const SliverToBoxAdapter(child: OrderStatusBanner()),
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 18),
+                  child: _GlassPanel(
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Row(
                           children: [
                             Expanded(
-                              child: OutlinedButton.icon(
+                              child: FilledButton.tonalIcon(
                                 onPressed: () => _showCategoryFilterSheet(context),
-                                icon: const Icon(Icons.filter_list_rounded),
+                                icon: const Icon(Icons.tune_rounded),
                                 label: Text(filterLabel),
+                                style: FilledButton.styleFrom(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 16,
+                                    vertical: 14,
+                                  ),
+                                ),
                               ),
                             ),
-                            if (selectedCategories.isNotEmpty) ...[
+                            if (hasSelections) ...[
                               const SizedBox(width: 12),
                               TextButton(
                                 onPressed: () => appState.clearCategoryFilter(),
@@ -172,88 +141,149 @@ class HomeScreen extends StatelessWidget {
                             ],
                           ],
                         ),
-                        const SizedBox(height: 16),
-                        SizedBox(
-                          height: 44,
-                          child: ListView.separated(
-                            scrollDirection: Axis.horizontal,
-                            itemBuilder: (context, index) {
-                              final category = categories[index];
-                              final isSelected = selectedCategories.contains(category.id);
-                              return ChoiceChip(
-                                label: Text(category.title),
-                                selected: isSelected,
-                                onSelected: (_) =>
-                                    context.read<AppState>().selectCategory(category.id),
-                              );
-                            },
-                            separatorBuilder: (_, __) => const SizedBox(width: 8),
-                            itemCount: categories.length,
-                          ),
+                        AnimatedSwitcher(
+                          duration: const Duration(milliseconds: 250),
+                          switchInCurve: Curves.easeOutCubic,
+                          switchOutCurve: Curves.easeInCubic,
+                          child: hasSelections
+                              ? Padding(
+                                  key: const ValueKey('selected-categories'),
+                                  padding: const EdgeInsets.only(top: 16),
+                                  child: Wrap(
+                                    spacing: 8,
+                                    runSpacing: 8,
+                                    children: selectedCategoryTitles
+                                        .map(
+                                          (title) => Chip(
+                                            label: Text(title),
+                                            avatar: Icon(
+                                              Icons.check_circle,
+                                              size: 18,
+                                              color: theme.colorScheme.primary,
+                                            ),
+                                          ),
+                                        )
+                                        .toList(),
+                                  ),
+                                )
+                              : const SizedBox.shrink(),
                         ),
+                        const SizedBox(height: 20),
+                        if (categories.isEmpty)
+                          Text(
+                            'Категории появятся после настройки меню в административной панели.',
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: theme.textTheme.bodyMedium?.color?.withOpacity(0.6),
+                            ),
+                          )
+                        else
+                          SizedBox(
+                            height: 52,
+                            child: ListView.separated(
+                              scrollDirection: Axis.horizontal,
+                              physics: const BouncingScrollPhysics(),
+                              itemBuilder: (context, index) {
+                                final category = categories[index];
+                                final isSelected =
+                                    selectedCategories.contains(category.id);
+                                return FilterChip(
+                                  label: Text(category.title),
+                                  selected: isSelected,
+                                  onSelected: (_) =>
+                                      context.read<AppState>().selectCategory(category.id),
+                                );
+                              },
+                              separatorBuilder: (_, __) => const SizedBox(width: 12),
+                              itemCount: categories.length,
+                            ),
+                          ),
                       ],
                     ),
                   ),
                 ),
               ),
-            ),
-            SliverPadding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              sliver: SliverLayoutBuilder(
-                builder: (context, constraints) {
-                  final width = constraints.crossAxisExtent;
-                  int crossAxisCount;
-                  if (width >= 1200) {
-                    crossAxisCount = 4;
-                  } else if (width >= 900) {
-                    crossAxisCount = 3;
-                  } else if (width >= 360) {
-                    crossAxisCount = 2;
-                  } else {
-                    crossAxisCount = 1;
-                  }
-                  if (crossAxisCount == 1) {
-                    return SliverList(
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                sliver: SliverLayoutBuilder(
+                  builder: (context, constraints) {
+                    final width = constraints.crossAxisExtent;
+                    int crossAxisCount;
+                    if (width >= 1200) {
+                      crossAxisCount = 4;
+                    } else if (width >= 900) {
+                      crossAxisCount = 3;
+                    } else if (width >= 360) {
+                      crossAxisCount = 2;
+                    } else {
+                      crossAxisCount = 1;
+                    }
+                    if (crossAxisCount == 1) {
+                      return SliverList(
+                        delegate: SliverChildBuilderDelegate(
+                          (context, index) => DishCard(dish: filteredDishes[index]),
+                          childCount: filteredDishes.length,
+                        ),
+                      );
+                    }
+                    final aspectRatio = crossAxisCount >= 3 ? 0.8 : 0.74;
+                    return SliverGrid(
+                      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: crossAxisCount,
+                        mainAxisSpacing: 20,
+                        crossAxisSpacing: 20,
+                        childAspectRatio: aspectRatio,
+                      ),
                       delegate: SliverChildBuilderDelegate(
-                        (context, index) => DishCard(dish: filteredDishes[index]),
+                        (context, index) {
+                          return DishCard(
+                            dish: filteredDishes[index],
+                            margin: EdgeInsets.zero,
+                          );
+                        },
                         childCount: filteredDishes.length,
                       ),
                     );
-                  }
-                  final aspectRatio = crossAxisCount >= 3 ? 0.82 : 0.72;
-                  return SliverGrid(
-                    gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                      crossAxisCount: crossAxisCount,
-                      mainAxisSpacing: 16,
-                      crossAxisSpacing: 16,
-                      childAspectRatio: aspectRatio,
-                    ),
-                    delegate: SliverChildBuilderDelegate(
-                      (context, index) {
-                        return DishCard(
-                          dish: filteredDishes[index],
-                          margin: EdgeInsets.zero,
-                        );
-                      },
-                      childCount: filteredDishes.length,
-                    ),
-                  );
-                },
-              ),
-            ),
-            if (filteredDishes.isEmpty)
-              const SliverToBoxAdapter(
-                child: Padding(
-                  padding: EdgeInsets.symmetric(vertical: 32),
-                  child: Center(
-                    child: Text('В выбранной категории пока нет доступных блюд.'),
-                  ),
+                  },
                 ),
               ),
-            const SliverToBoxAdapter(child: SizedBox(height: 120)),
-          ],
+              if (filteredDishes.isEmpty)
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(32, 40, 32, 80),
+                    child: _GlassPanel(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            Icons.restaurant_menu,
+                            size: 48,
+                            color: theme.colorScheme.primary,
+                          ),
+                          const SizedBox(height: 16),
+                          Text(
+                            'В выбранной категории пока нет блюд',
+                            style: theme.textTheme.titleMedium,
+                            textAlign: TextAlign.center,
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            'Снимите фильтр или загляните позже — команда уже работает над новинками.',
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color:
+                                  theme.textTheme.bodyMedium?.color?.withOpacity(0.7),
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              const SliverToBoxAdapter(child: SizedBox(height: 120)),
+            ],
+          ),
         ),
-      ),
+      ],
     );
   }
 }
@@ -279,39 +309,44 @@ void _showCategoryFilterSheet(BuildContext context) async {
                 children: [
                   Text(
                     'Фильтр по категориям',
-                    style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+                    style:
+                        theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
                   ),
                   const SizedBox(height: 16),
                   ConstrainedBox(
                     constraints: BoxConstraints(
-                      maxHeight: MediaQuery.of(context).size.height * 0.5,
+                      maxHeight: MediaQuery.of(context).size.height * 0.55,
                     ),
-                    child: ListView(
-                      shrinkWrap: true,
-                      children: [
-                        CheckboxListTile(
-                          value: localSelected.isEmpty,
-                          onChanged: (_) {
-                            setState(() => localSelected.clear());
-                          },
-                          title: const Text('Все категории'),
-                        ),
-                        ...categories.map(
-                          (category) => CheckboxListTile(
-                            value: localSelected.contains(category.id),
-                            onChanged: (value) {
-                              setState(() {
-                                if (value ?? false) {
-                                  localSelected.add(category.id);
-                                } else {
-                                  localSelected.remove(category.id);
-                                }
-                              });
+                    child: Material(
+                      color: Colors.transparent,
+                      child: ListView(
+                        shrinkWrap: true,
+                        children: [
+                          CheckboxListTile(
+                            value: localSelected.isEmpty,
+                            onChanged: (_) {
+                              setState(() => localSelected.clear());
                             },
-                            title: Text(category.title),
+                            title: const Text('Все категории'),
                           ),
-                        ),
-                      ],
+                          const Divider(),
+                          ...categories.map(
+                            (category) => CheckboxListTile(
+                              value: localSelected.contains(category.id),
+                              onChanged: (value) {
+                                setState(() {
+                                  if (value ?? false) {
+                                    localSelected.add(category.id);
+                                  } else {
+                                    localSelected.remove(category.id);
+                                  }
+                                });
+                              },
+                              title: Text(category.title),
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                   const SizedBox(height: 20),
@@ -354,28 +389,315 @@ void _showCategoryFilterSheet(BuildContext context) async {
   }
 }
 
-Widget _buildInfoChip(BuildContext context, IconData icon, String label) {
-  return DecoratedBox(
-    decoration: BoxDecoration(
-      color: Colors.white.withOpacity(0.14),
-      borderRadius: BorderRadius.circular(24),
-    ),
-    child: Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, size: 18, color: Colors.white),
-          const SizedBox(width: 8),
-          Text(
-            label,
-            style: Theme.of(context)
-                .textTheme
-                .bodyMedium
-                ?.copyWith(color: Colors.white, fontWeight: FontWeight.w600),
+class _GlassPanel extends StatelessWidget {
+  const _GlassPanel({required this.child, this.padding});
+
+  final Widget child;
+  final EdgeInsetsGeometry? padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final borderRadius = BorderRadius.circular(28);
+    return ClipRRect(
+      borderRadius: borderRadius,
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 22, sigmaY: 22),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            borderRadius: borderRadius,
+            color: Colors.white.withOpacity(0.72),
+            border: Border.all(color: Colors.white.withOpacity(0.3)),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.05),
+                blurRadius: 24,
+                offset: const Offset(0, 14),
+              ),
+            ],
+          ),
+          child: Padding(
+            padding: padding ?? const EdgeInsets.all(24),
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _HomeBackground extends StatelessWidget {
+  const _HomeBackground();
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Positioned.fill(
+      child: IgnorePointer(
+        child: DecoratedBox(
+          decoration: const BoxDecoration(
+            gradient: LinearGradient(
+              colors: [Color(0xFFFFF4ED), Color(0xFFFFFBF8)],
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+            ),
+          ),
+          child: Stack(
+            children: [
+              _BlurOrb(
+                color: scheme.primary.withOpacity(0.25),
+                size: 240,
+                top: -60,
+                left: -80,
+              ),
+              _BlurOrb(
+                color: scheme.secondary.withOpacity(0.18),
+                size: 200,
+                top: 140,
+                right: -60,
+              ),
+              _BlurOrb(
+                color: scheme.primaryContainer.withOpacity(0.2),
+                size: 280,
+                bottom: -140,
+                left: -40,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BlurOrb extends StatelessWidget {
+  const _BlurOrb({
+    required this.color,
+    required this.size,
+    this.top,
+    this.left,
+    this.right,
+    this.bottom,
+  });
+
+  final Color color;
+  final double size;
+  final double? top;
+  final double? left;
+  final double? right;
+  final double? bottom;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      top: top,
+      left: left,
+      right: right,
+      bottom: bottom,
+      child: Container(
+        width: size,
+        height: size,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          gradient: RadialGradient(
+            colors: [
+              color,
+              color.withOpacity(0.01),
+            ],
+            stops: const [0.1, 1],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _HeroHeader extends StatelessWidget {
+  const _HeroHeader({required this.info, required this.progress});
+
+  final RestaurantInfo info;
+  final double progress;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final name = info.name.isNotEmpty ? info.name : 'ваш ресторан';
+    final workingHours = info.workingHours.isNotEmpty ? info.workingHours : null;
+    final phone = info.phone.isNotEmpty ? info.phone : null;
+    final overlay = 0.18 + progress * 0.2;
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeOutCubic,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(32),
+        gradient: LinearGradient(
+          colors: [
+            theme.colorScheme.primary,
+            theme.colorScheme.primaryContainer.withOpacity(0.9),
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: theme.colorScheme.primary.withOpacity(0.25),
+            blurRadius: 36,
+            offset: const Offset(0, 18),
           ),
         ],
       ),
-    ),
-  );
+      child: Stack(
+        children: [
+          Positioned(
+            top: -50,
+            right: -40,
+            child: _OrnamentCircle(
+              size: 160,
+              color: Colors.white.withOpacity(overlay),
+            ),
+          ),
+          Positioned(
+            bottom: -60,
+            left: -20,
+            child: _OrnamentCircle(
+              size: 200,
+              color: Colors.white.withOpacity(overlay * 0.8),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(28),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: Colors.white.withOpacity(0.14 + progress * 0.1),
+                    borderRadius: BorderRadius.circular(18),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Icon(
+                          Icons.local_fire_department_outlined,
+                          color: Colors.white,
+                          size: 18,
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          'Авторская кухня',
+                          style: theme.textTheme.labelLarge?.copyWith(
+                            color: Colors.white,
+                            fontWeight: FontWeight.w600,
+                            letterSpacing: 0.2,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 18),
+                Text(
+                  'Добро пожаловать в ${name.isNotEmpty ? name : 'Firdusi Food'}',
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: -0.4,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  'Выбирайте блюда, вдохновленные восточными традициями и современными гастротрендами.',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: Colors.white.withOpacity(0.82),
+                  ),
+                ),
+                if (workingHours != null || phone != null) ...[
+                  const SizedBox(height: 18),
+                  Wrap(
+                    spacing: 12,
+                    runSpacing: 12,
+                    children: [
+                      if (workingHours != null)
+                        _HeaderInfoChip(
+                          icon: Icons.schedule_outlined,
+                          label: workingHours,
+                        ),
+                      if (phone != null)
+                        _HeaderInfoChip(
+                          icon: Icons.phone_in_talk_outlined,
+                          label: phone,
+                        ),
+                    ],
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _OrnamentCircle extends StatelessWidget {
+  const _OrnamentCircle({required this.size, required this.color});
+
+  final double size;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        gradient: RadialGradient(
+          colors: [
+            color,
+            color.withOpacity(0.01),
+          ],
+          stops: const [0.1, 1],
+        ),
+      ),
+    );
+  }
+}
+
+class _HeaderInfoChip extends StatelessWidget {
+  const _HeaderInfoChip({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Colors.white.withOpacity(0.18),
+        borderRadius: BorderRadius.circular(22),
+        border: Border.all(color: Colors.white.withOpacity(0.25)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 18, color: Colors.white),
+            const SizedBox(width: 8),
+            Text(
+              label,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: Colors.white,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }

--- a/lib/screens/main_shell.dart
+++ b/lib/screens/main_shell.dart
@@ -19,6 +19,7 @@ class _MainShellState extends State<MainShell> {
   @override
   Widget build(BuildContext context) {
     final appState = context.watch<AppState>();
+    final theme = Theme.of(context);
     final destinations = [
       const NavigationDestination(icon: Icon(Icons.restaurant_menu), label: 'Меню'),
       NavigationDestination(
@@ -50,10 +51,29 @@ class _MainShellState extends State<MainShell> {
         index: _index,
         children: const [HomeScreen(), CartScreen(), ProfileScreen()],
       ),
-      bottomNavigationBar: NavigationBar(
-        selectedIndex: _index,
-        destinations: destinations,
-        onDestinationSelected: (value) => setState(() => _index = value),
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(28),
+            boxShadow: [
+              BoxShadow(
+                color: theme.colorScheme.primary.withOpacity(0.12),
+                blurRadius: 32,
+                offset: const Offset(0, 18),
+              ),
+            ],
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(28),
+            child: NavigationBar(
+              selectedIndex: _index,
+              destinations: destinations,
+              onDestinationSelected: (value) => setState(() => _index = value),
+              elevation: 0,
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -1,58 +1,165 @@
 import 'package:flutter/material.dart';
 
 ThemeData buildTheme() {
-  const seed = Color(0xFF9C2B31);
+  const seed = Color(0xFFE0493E);
   final base = ThemeData.light(useMaterial3: true);
   final scheme = ColorScheme.fromSeed(seedColor: seed, brightness: Brightness.light);
 
-  return base.copyWith(
-    scaffoldBackgroundColor: const Color(0xFFFFFAF4),
-    colorScheme: scheme.copyWith(surfaceTint: Colors.transparent),
-    textTheme: base.textTheme.apply(
-      bodyColor: const Color(0xFF2A1B1A),
-      displayColor: const Color(0xFF2A1B1A),
-      fontFamily: 'Roboto',
+  final textTheme = base.textTheme.apply(
+    bodyColor: const Color(0xFF241919),
+    displayColor: const Color(0xFF241919),
+    fontFamily: 'Roboto',
+  ).copyWith(
+    headlineLarge: base.textTheme.headlineLarge?.copyWith(letterSpacing: -0.6),
+    headlineMedium: base.textTheme.headlineMedium?.copyWith(letterSpacing: -0.4),
+    headlineSmall: base.textTheme.headlineSmall?.copyWith(
+      letterSpacing: -0.2,
+      fontWeight: FontWeight.w700,
     ),
+    titleLarge: base.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
+    titleMedium: base.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+    titleSmall: base.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+  );
+
+  return base.copyWith(
+    visualDensity: VisualDensity.adaptivePlatformDensity,
+    scaffoldBackgroundColor: const Color(0xFFFEF8F2),
+    colorScheme: scheme.copyWith(surfaceTint: Colors.transparent),
+    textTheme: textTheme,
     appBarTheme: AppBarTheme(
-      backgroundColor: scheme.primary,
-      foregroundColor: Colors.white,
-      titleTextStyle: base.textTheme.titleLarge?.copyWith(
-        color: Colors.white,
-        fontWeight: FontWeight.w700,
+      backgroundColor: Colors.transparent,
+      foregroundColor: textTheme.titleLarge?.color,
+      elevation: 0,
+      centerTitle: false,
+      surfaceTintColor: Colors.transparent,
+      titleTextStyle: textTheme.titleLarge,
+    ),
+    navigationBarTheme: NavigationBarThemeData(
+      backgroundColor: Colors.white.withOpacity(0.85),
+      indicatorColor: scheme.primary.withOpacity(0.15),
+      surfaceTintColor: Colors.transparent,
+      height: 68,
+      labelBehavior: NavigationDestinationLabelBehavior.onlyShowSelected,
+      elevation: 0,
+      labelTextStyle: MaterialStateProperty.resolveWith(
+        (states) {
+          final isSelected = states.contains(MaterialState.selected);
+          return textTheme.labelMedium?.copyWith(
+            fontWeight: isSelected ? FontWeight.w700 : FontWeight.w500,
+            color: isSelected
+                ? scheme.primary
+                : textTheme.labelMedium?.color?.withOpacity(0.7),
+          );
+        },
+      ),
+      iconTheme: MaterialStateProperty.resolveWith(
+        (states) {
+          final baseColor = states.contains(MaterialState.selected)
+              ? scheme.primary
+              : textTheme.bodyMedium?.color?.withOpacity(0.7);
+          return IconThemeData(color: baseColor, size: 26);
+        },
       ),
     ),
     chipTheme: base.chipTheme.copyWith(
-      selectedColor: scheme.primary.withOpacity(0.15),
-      side: BorderSide(color: scheme.primary.withOpacity(0.25)),
+      selectedColor: scheme.primary.withOpacity(0.12),
+      backgroundColor: Colors.white.withOpacity(0.7),
+      side: BorderSide(color: scheme.outlineVariant.withOpacity(0.4)),
       showCheckmark: false,
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-      labelStyle: base.textTheme.labelLarge,
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+      labelStyle: textTheme.labelLarge,
     ),
     elevatedButtonTheme: ElevatedButtonThemeData(
       style: ElevatedButton.styleFrom(
         backgroundColor: scheme.primary,
         foregroundColor: Colors.white,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 16),
-        textStyle: base.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+        shadowColor: scheme.primary.withOpacity(0.35),
+        elevation: 0,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+        padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 18),
+        textStyle: textTheme.titleMedium,
       ),
     ),
     filledButtonTheme: FilledButtonThemeData(
       style: FilledButton.styleFrom(
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 16),
-        textStyle: base.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+        backgroundColor: scheme.secondaryContainer,
+        foregroundColor: scheme.onSecondaryContainer,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+        padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 18),
+        textStyle: textTheme.titleMedium,
+      ),
+    ),
+    outlinedButtonTheme: OutlinedButtonThemeData(
+      style: OutlinedButton.styleFrom(
+        foregroundColor: scheme.primary,
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+        textStyle: textTheme.titleMedium,
+        side: BorderSide(color: scheme.primary.withOpacity(0.4), width: 1.2),
+      ),
+    ),
+    textButtonTheme: TextButtonThemeData(
+      style: TextButton.styleFrom(
+        foregroundColor: scheme.primary,
+        textStyle: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
       ),
     ),
     inputDecorationTheme: base.inputDecorationTheme.copyWith(
-      border: OutlineInputBorder(borderRadius: BorderRadius.circular(16)),
+      border: OutlineInputBorder(borderRadius: BorderRadius.circular(20)),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(20),
+        borderSide: BorderSide(color: scheme.outlineVariant.withOpacity(0.4)),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(20),
+        borderSide: BorderSide(color: scheme.primary, width: 1.6),
+      ),
       filled: true,
       fillColor: Colors.white,
+      hintStyle: textTheme.bodyMedium?.copyWith(color: textTheme.bodyMedium?.color?.withOpacity(0.5)),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 20),
     ),
     cardTheme: base.cardTheme.copyWith(
-      elevation: 4,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+      color: Colors.white,
+      elevation: 5,
+      shadowColor: Colors.black.withOpacity(0.05),
+      surfaceTintColor: Colors.transparent,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
       clipBehavior: Clip.antiAlias,
+    ),
+    bottomSheetTheme: BottomSheetThemeData(
+      backgroundColor: Colors.white,
+      surfaceTintColor: Colors.transparent,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(32)),
+      ),
+    ),
+    dialogTheme: DialogTheme(
+      backgroundColor: Colors.white,
+      surfaceTintColor: Colors.transparent,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
+      titleTextStyle: textTheme.titleLarge,
+      contentTextStyle: textTheme.bodyMedium,
+    ),
+    listTileTheme: ListTileThemeData(
+      tileColor: Colors.white,
+      selectedTileColor: scheme.primary.withOpacity(0.1),
+      iconColor: scheme.primary,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+    ),
+    dividerTheme: base.dividerTheme.copyWith(
+      color: scheme.outlineVariant.withOpacity(0.35),
+      thickness: 0.8,
+    ),
+    progressIndicatorTheme: base.progressIndicatorTheme.copyWith(
+      color: scheme.primary,
+      circularTrackColor: scheme.primary.withOpacity(0.2),
+    ),
+    snackBarTheme: SnackBarThemeData(
+      behavior: SnackBarBehavior.floating,
+      backgroundColor: scheme.primary,
+      contentTextStyle: textTheme.bodyMedium?.copyWith(color: Colors.white),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
     ),
   );
 }

--- a/lib/widgets/dish_card.dart
+++ b/lib/widgets/dish_card.dart
@@ -21,118 +21,121 @@ class DishCard extends StatelessWidget {
 
     final theme = Theme.of(context);
     final isCompact = margin == EdgeInsets.zero;
-    return Card(
-      margin: margin ?? const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-      clipBehavior: Clip.antiAlias,
-      elevation: isCompact ? 3 : 6,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(isCompact ? 20 : 28),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          AspectRatio(
-            aspectRatio: 16 / 9,
-            child: Stack(
-              fit: StackFit.expand,
-              children: [
-                Ink.image(
-                  image: NetworkImage(dish.imageUrl),
-                  fit: BoxFit.cover,
-                  child: InkWell(onTap: () => _showDetails(context)),
-                ),
-                Positioned(
-                  right: 16,
-                  top: 16,
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      color: Colors.black54,
-                      borderRadius: BorderRadius.circular(16),
-                    ),
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                      child: Text(
-                        '${dish.weight} г',
-                        style: theme.textTheme.labelMedium?.copyWith(color: Colors.white),
-                      ),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-          Padding(
-            padding: EdgeInsets.fromLTRB(
-              isCompact ? 16 : 20,
-              isCompact ? 14 : 18,
-              isCompact ? 16 : 20,
-              isCompact ? 12 : 16,
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  dish.name,
-                  style: theme.textTheme.titleLarge,
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  dish.description,
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    color: theme.colorScheme.onSurface.withOpacity(0.72),
-                  ),
-                  maxLines: isCompact ? 3 : null,
-                  overflow:
-                      isCompact ? TextOverflow.ellipsis : TextOverflow.visible,
-                ),
-                const SizedBox(height: 12),
-                Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(
-                      Icons.scale_outlined,
-                      size: 18,
-                      color: theme.colorScheme.onSurface.withOpacity(0.6),
-                    ),
-                    const SizedBox(width: 6),
-                    Text(
-                      '${dish.weight} г',
-                      style: theme.textTheme.labelMedium?.copyWith(
-                        color: theme.colorScheme.onSurface.withOpacity(0.72),
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 12),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          '${dish.price.toStringAsFixed(0)} ₽',
-                          style: theme.textTheme.headlineSmall?.copyWith(
-                            fontWeight: FontWeight.w700,
-                            color: theme.colorScheme.primary,
-                          ),
-                        ),
-                      ],
-                    ),
-                    quantity == 0
-                        ? FilledButton.icon(
-                            onPressed: () => context.read<AppState>().addDish(dish),
-                            icon: const Icon(Icons.add_circle_outline),
-                            label: const Text('Добавить'),
-                          )
-                        : _QuantityControl(dish: dish, quantity: quantity),
-                  ],
-                ),
-              ],
-            ),
+
+    return Container(
+      margin: margin ?? const EdgeInsets.symmetric(vertical: 10, horizontal: 16),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(isCompact ? 26 : 32),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: isCompact ? 18 : 26,
+            offset: const Offset(0, 12),
           ),
         ],
+      ),
+      child: Card(
+        margin: EdgeInsets.zero,
+        elevation: 0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(isCompact ? 26 : 32),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _DishImage(
+              dish: dish,
+              isCompact: isCompact,
+              onTap: () => _showDetails(context),
+            ),
+            Padding(
+              padding: EdgeInsets.fromLTRB(
+                isCompact ? 18 : 24,
+                isCompact ? 16 : 22,
+                isCompact ? 18 : 24,
+                isCompact ? 18 : 22,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    dish.name,
+                    style: theme.textTheme.titleLarge,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    dish.description,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurface.withOpacity(0.7),
+                      height: 1.4,
+                    ),
+                    maxLines: isCompact ? 3 : 4,
+                    overflow:
+                        isCompact ? TextOverflow.ellipsis : TextOverflow.visible,
+                  ),
+                  const SizedBox(height: 16),
+                  Wrap(
+                    spacing: 10,
+                    runSpacing: 10,
+                    children: [
+                      _FeatureChip(
+                        icon: Icons.scale_outlined,
+                        label: '${dish.weight} г',
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 20),
+                  Row(
+                    children: [
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Стоимость',
+                            style: theme.textTheme.labelMedium?.copyWith(
+                              color:
+                                  theme.colorScheme.onSurface.withOpacity(0.55),
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            '${dish.price.toStringAsFixed(0)} ₽',
+                            style: theme.textTheme.headlineSmall?.copyWith(
+                              fontWeight: FontWeight.w700,
+                              color: theme.colorScheme.primary,
+                            ),
+                          ),
+                        ],
+                      ),
+                      const Spacer(),
+                      AnimatedSwitcher(
+                        duration: const Duration(milliseconds: 220),
+                        switchInCurve: Curves.easeOutCubic,
+                        switchOutCurve: Curves.easeInCubic,
+                        transitionBuilder: (child, animation) => ScaleTransition(
+                          scale: animation,
+                          child: child,
+                        ),
+                        child: quantity == 0
+                            ? FilledButton.icon(
+                                key: const ValueKey('add-button'),
+                                onPressed: () => context.read<AppState>().addDish(dish),
+                                icon: const Icon(Icons.add_circle_outline),
+                                label: const Text('В корзину'),
+                              )
+                            : _QuantityControl(
+                                key: ValueKey('quantity-$quantity'),
+                                dish: dish,
+                                quantity: quantity,
+                              ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -146,6 +149,82 @@ class DishCard extends StatelessWidget {
   }
 }
 
+class _DishImage extends StatelessWidget {
+  const _DishImage({
+    required this.dish,
+    required this.isCompact,
+    required this.onTap,
+  });
+
+  final Dish dish;
+  final bool isCompact;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ClipRRect(
+      borderRadius: BorderRadius.vertical(
+        top: Radius.circular(isCompact ? 26 : 32),
+      ),
+      child: InkWell(
+        onTap: onTap,
+        child: Ink(
+          decoration: const BoxDecoration(color: Colors.black12),
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              Ink.image(
+                image: NetworkImage(dish.imageUrl),
+                fit: BoxFit.cover,
+              ),
+              Container(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [
+                      Colors.black.withOpacity(0.0),
+                      Colors.black.withOpacity(0.45),
+                    ],
+                  ),
+                ),
+              ),
+              Positioned(
+                left: 18,
+                bottom: 18,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(18),
+                    color: theme.colorScheme.primary.withOpacity(0.9),
+                    boxShadow: [
+                      BoxShadow(
+                        color: theme.colorScheme.primary.withOpacity(0.25),
+                        blurRadius: 12,
+                        offset: const Offset(0, 6),
+                      ),
+                    ],
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+                    child: Text(
+                      '${dish.price.toStringAsFixed(0)} ₽',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _DishDetails extends StatelessWidget {
   const _DishDetails({required this.dish});
 
@@ -153,43 +232,81 @@ class _DishDetails extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final appState = context.watch<AppState>();
     final quantity = appState.cart[dish.id] ?? 0;
+
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+      padding: EdgeInsets.only(
+        left: 24,
+        right: 24,
+        top: 16,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 24,
+      ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(dish.name, style: Theme.of(context).textTheme.titleLarge),
+          Text(dish.name, style: theme.textTheme.titleLarge),
           const SizedBox(height: 12),
-          Text(dish.description),
-          const SizedBox(height: 12),
+          Text(
+            dish.description,
+            style: theme.textTheme.bodyMedium?.copyWith(height: 1.4),
+          ),
+          const SizedBox(height: 16),
+          Wrap(
+            spacing: 10,
+            runSpacing: 10,
+            children: [
+              _FeatureChip(
+                icon: Icons.scale_outlined,
+                label: '${dish.weight} г',
+              ),
+            ],
+          ),
+          const SizedBox(height: 20),
           Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    '${dish.price.toStringAsFixed(0)} ₽',
-                    style: Theme.of(context).textTheme.titleMedium,
+                    'Стоимость',
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: theme.colorScheme.onSurface.withOpacity(0.6),
+                    ),
                   ),
+                  const SizedBox(height: 4),
                   Text(
-                    '${dish.weight} г',
-                    style: Theme.of(context)
-                        .textTheme
-                        .labelMedium
-                        ?.copyWith(color: Colors.grey[600]),
+                    '${dish.price.toStringAsFixed(0)} ₽',
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w700,
+                      color: theme.colorScheme.primary,
+                    ),
                   ),
                 ],
               ),
-              quantity == 0
-                  ? FilledButton(
-                      onPressed: () => context.read<AppState>().addDish(dish),
-                      child: const Text('Добавить'),
-                    )
-                  : _QuantityControl(dish: dish, quantity: quantity),
+              const Spacer(),
+              AnimatedSwitcher(
+                duration: const Duration(milliseconds: 220),
+                switchInCurve: Curves.easeOutCubic,
+                switchOutCurve: Curves.easeInCubic,
+                transitionBuilder: (child, animation) => ScaleTransition(
+                  scale: animation,
+                  child: child,
+                ),
+                child: quantity == 0
+                    ? FilledButton(
+                        key: const ValueKey('details-add-button'),
+                        onPressed: () => context.read<AppState>().addDish(dish),
+                        child: const Text('Добавить'),
+                      )
+                    : _QuantityControl(
+                        key: ValueKey('details-quantity-$quantity'),
+                        dish: dish,
+                        quantity: quantity,
+                      ),
+              ),
             ],
           ),
         ],
@@ -199,30 +316,73 @@ class _DishDetails extends StatelessWidget {
 }
 
 class _QuantityControl extends StatelessWidget {
-  const _QuantityControl({required this.dish, required this.quantity});
+  const _QuantityControl({super.key, required this.dish, required this.quantity});
 
   final Dish dish;
   final int quantity;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    final theme = Theme.of(context);
+    return DecoratedBox(
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(24),
-        color: Theme.of(context).colorScheme.primary.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(26),
+        color: theme.colorScheme.primary.withOpacity(0.1),
       ),
       child: Row(
+        mainAxisSize: MainAxisSize.min,
         children: [
           IconButton(
-            icon: const Icon(Icons.remove_circle_outline),
+            icon: const Icon(Icons.remove_rounded),
             onPressed: () => context.read<AppState>().decrementDish(dish.id),
           ),
-          Text('$quantity', style: Theme.of(context).textTheme.titleMedium),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 6),
+            child: Text(
+              '$quantity',
+              style: theme.textTheme.titleMedium,
+            ),
+          ),
           IconButton(
-            icon: const Icon(Icons.add_circle_outline),
+            icon: const Icon(Icons.add_rounded),
             onPressed: () => context.read<AppState>().incrementDish(dish.id),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _FeatureChip extends StatelessWidget {
+  const _FeatureChip({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(18),
+        color: theme.colorScheme.primary.withOpacity(0.08),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 16, color: theme.colorScheme.primary),
+            const SizedBox(width: 6),
+            Text(
+              label,
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: theme.colorScheme.primary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/widgets/order_status_banner.dart
+++ b/lib/widgets/order_status_banner.dart
@@ -16,57 +16,110 @@ class OrderStatusBanner extends StatelessWidget {
     }
 
     final statusText = _statusLabel(order.status);
+    final statusIcon = _statusIcon(order.status);
+    final progress = _statusProgress(order.status);
     final dateFormat = DateFormat('dd MMM HH:mm');
     final theme = Theme.of(context);
     final locationText = order.mode == DeliveryMode.pickup
         ? (order.address.isNotEmpty ? 'Самовывоз · ${order.address}' : 'Самовывоз')
         : (order.address.isNotEmpty ? order.address : 'Адрес не указан');
     final intervalText = order.deliveryInterval;
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 24),
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            colors: [theme.colorScheme.primary, theme.colorScheme.primaryContainer],
+      child: TweenAnimationBuilder<double>(
+        tween: Tween(begin: 0, end: 1),
+        duration: const Duration(milliseconds: 350),
+        curve: Curves.easeOutCubic,
+        builder: (context, value, child) => Opacity(opacity: value, child: child),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              colors: [
+                theme.colorScheme.primary,
+                theme.colorScheme.primaryContainer,
+              ],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            borderRadius: BorderRadius.circular(28),
+            boxShadow: [
+              BoxShadow(
+                color: theme.colorScheme.primary.withOpacity(0.2),
+                blurRadius: 26,
+                offset: const Offset(0, 16),
+              ),
+            ],
           ),
-          borderRadius: BorderRadius.circular(24),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(20),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Ваш заказ в пути',
-                style: theme.textTheme.titleMedium?.copyWith(
-                  color: Colors.white,
-                  fontWeight: FontWeight.w600,
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    CircleAvatar(
+                      radius: 26,
+                      backgroundColor: Colors.white.withOpacity(0.16),
+                      child: Icon(statusIcon, color: Colors.white, size: 26),
+                    ),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Ваш заказ в пути',
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w600,
+                              letterSpacing: 0.2,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            '№ ${order.id} · $statusText · ${dateFormat.format(order.createdAt)}',
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: Colors.white.withOpacity(0.85),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
                 ),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                '№ ${order.id} · $statusText · ${dateFormat.format(order.createdAt)}',
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  color: Colors.white.withOpacity(0.86),
+                const SizedBox(height: 16),
+                Wrap(
+                  spacing: 12,
+                  runSpacing: 12,
+                  children: [
+                    _StatusChip(
+                      icon: Icons.receipt_long_outlined,
+                      label: 'Сумма: ${order.total.toStringAsFixed(0)} ₽',
+                    ),
+                    _StatusChip(
+                      icon: Icons.place_outlined,
+                      label: locationText,
+                    ),
+                    if (intervalText != null && intervalText.isNotEmpty)
+                      _StatusChip(
+                        icon: Icons.access_time,
+                        label: 'Интервал: $intervalText',
+                      ),
+                  ],
                 ),
-              ),
-              const SizedBox(height: 4),
-              Text(
-                'Сумма: ${order.total.toStringAsFixed(0)} ₽ · $locationText',
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  color: Colors.white.withOpacity(0.86),
-                ),
-              ),
-              if (intervalText != null && intervalText.isNotEmpty) ...[
-                const SizedBox(height: 4),
-                Text(
-                  'Интервал: $intervalText',
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    color: Colors.white.withOpacity(0.86),
+                const SizedBox(height: 20),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(12),
+                  child: LinearProgressIndicator(
+                    value: progress,
+                    minHeight: 6,
+                    backgroundColor: Colors.white.withOpacity(0.2),
+                    valueColor: const AlwaysStoppedAnimation<Color>(Colors.white),
                   ),
                 ),
               ],
-            ],
+            ),
           ),
         ),
       ),
@@ -88,5 +141,74 @@ class OrderStatusBanner extends StatelessWidget {
       case OrderStatus.cancelled:
         return 'Отменен';
     }
+  }
+
+  IconData _statusIcon(OrderStatus status) {
+    switch (status) {
+      case OrderStatus.pending:
+        return Icons.watch_later_outlined;
+      case OrderStatus.accepted:
+        return Icons.how_to_reg_outlined;
+      case OrderStatus.cooking:
+        return Icons.local_fire_department_outlined;
+      case OrderStatus.delivering:
+        return Icons.delivery_dining;
+      case OrderStatus.completed:
+        return Icons.emoji_events_outlined;
+      case OrderStatus.cancelled:
+        return Icons.block_outlined;
+    }
+  }
+
+  double _statusProgress(OrderStatus status) {
+    switch (status) {
+      case OrderStatus.pending:
+        return 0.2;
+      case OrderStatus.accepted:
+        return 0.4;
+      case OrderStatus.cooking:
+        return 0.6;
+      case OrderStatus.delivering:
+        return 0.85;
+      case OrderStatus.completed:
+        return 1.0;
+      case OrderStatus.cancelled:
+        return 1.0;
+    }
+  }
+}
+
+class _StatusChip extends StatelessWidget {
+  const _StatusChip({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Colors.white.withOpacity(0.18),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: Colors.white.withOpacity(0.25)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 18, color: Colors.white),
+            const SizedBox(width: 8),
+            Text(
+              label,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w600,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }


### PR DESCRIPTION
## Summary
- refresh the Material 3 theme with updated typography, button styles, navigation bar chrome, and glassmorphism surfaces
- redesign the home screen hero, background, and filtering controls to deliver a richer landing experience
- restyle dish cards and the active order banner with gradients, chips, and animated quantity controls

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e08a105c688328aa78a55c19f63c3d